### PR TITLE
Fix for Read_ofx_content_53 unit test under mono.

### DIFF
--- a/sgmlreaderdll/SgmlReader.cs
+++ b/sgmlreaderdll/SgmlReader.cs
@@ -465,7 +465,7 @@ namespace Sgml
                     }
                     else
                     {
-                        baseUri = new Uri(new Uri(Directory.GetCurrentDirectory() + "\\"), this.m_syslit);
+                        baseUri = new Uri(new Uri(Directory.GetCurrentDirectory() + "/"), this.m_syslit);
                     }
                     this.m_dtd = SgmlDtd.Parse(baseUri, this.m_docType, this.m_pubid, baseUri.AbsoluteUri, this.m_subset, this.m_proxy, null);
                 }


### PR DESCRIPTION
This fixes test unit Read_ofx_content_53 under mono, which doesn't recognize the backslash at the end of the URI and then constructs the wrong path for the DTD look up when it appends its name as a relative path.
