### PR TITLE
Update the name of the included dtd-resource

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -14,7 +14,7 @@ task Init -depends Clean {
 
 task Compile -depends Init { 
     $sources = gci ".\sgmlreaderdll" -r -fi *.cs |% { $_.FullName }
-    csc /target:library /out:$out $sources /keyfile:.\sgmlreaderdll\sgmlreader.snk /resource:.\SgmlReader\Html.dtd
+    csc /target:library /out:$out $sources /keyfile:.\sgmlreaderdll\sgmlreader.snk /resource:".\SgmlReader\Html.dtd,SgmlReaderDll.Html.dtd"
 }
 
 task Test -depends Compile {


### PR DESCRIPTION
In the code the reference is named with a prefix. The nuget script now use the same name.
