### PR TITLE
Add new .NETPortable class-library build of SgmlReaderDll.

### DIFF
--- a/SgmlReader.sln
+++ b/SgmlReader.sln
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Demo.aspx = Demo.aspx
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SgmlReaderPortable", "SgmlReaderPortable\SgmlReaderPortable.csproj", "{39844234-3DD6-4527-8852-BCAC4B3B97A0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,6 +42,12 @@ Global
 		{9CC3FC29-375F-44F1-95BE-D52246CC7B3E}.Default|Any CPU.Build.0 = Debug|Any CPU
 		{9CC3FC29-375F-44F1-95BE-D52246CC7B3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9CC3FC29-375F-44F1-95BE-D52246CC7B3E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39844234-3DD6-4527-8852-BCAC4B3B97A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39844234-3DD6-4527-8852-BCAC4B3B97A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39844234-3DD6-4527-8852-BCAC4B3B97A0}.Default|Any CPU.ActiveCfg = Debug|Any CPU
+		{39844234-3DD6-4527-8852-BCAC4B3B97A0}.Default|Any CPU.Build.0 = Debug|Any CPU
+		{39844234-3DD6-4527-8852-BCAC4B3B97A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39844234-3DD6-4527-8852-BCAC4B3B97A0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection

--- a/SgmlReaderPortable/Properties/AssemblyInfo.cs
+++ b/SgmlReaderPortable/Properties/AssemblyInfo.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Resources;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SgmlReaderPortable")]
+[assembly: AssemblyDescription("Converts SGML to XML via XmlReader API")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft, MindTouch")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("Copyright (c) 2002, Microsoft Corporation; Copyright (c) 2007-2013, MindTouch")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: CLSCompliant(true)]
+[assembly: NeutralResourcesLanguage("en")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SgmlReaderPortable/SgmlReaderPortable.csproj
+++ b/SgmlReaderPortable/SgmlReaderPortable.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{39844234-3DD6-4527-8852-BCAC4B3B97A0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SgmlReaderPortable</RootNamespace>
+    <AssemblyName>SgmlReaderPortable</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile158</TargetFrameworkProfile>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;PORTABLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+    <EmbeddedResource Include="..\SgmlReader\Html.dtd">
+      <Link>Html.dtd</Link>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\sgmlreaderdll\SgmlParser.cs">
+      <Link>SgmlParser.cs</Link>
+    </Compile>
+    <Compile Include="..\sgmlreaderdll\SgmlReader.cs">
+      <Link>SgmlReader.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
This commit creates a new c# project that targets the .NETPortable runtime including .NET 4.5, Silverlight 5, Windows Phone 8 and .NET for Windows Store apps. This allows the client to be used by projects targeting those frameworks.

Define Constants are used to selectively enable functionality not present in these lighter frameworks.

I didn't create a new nuspec for this library because it would require additional changes to the PSake build scripts to accomplish and felt someone else might know how to do this more quickly than I can.
