### PR TITLE
Fix reading HTML via XmlReader API when root element is absent

### DIFF
--- a/sgmlreaderdll/AssemblyInfo.cs
+++ b/sgmlreaderdll/AssemblyInfo.cs
@@ -50,8 +50,8 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("1.8.12")]
-[assembly: AssemblyFileVersion("1.8.12")]
+[assembly: AssemblyVersion("1.8.12.1")]
+[assembly: AssemblyFileVersion("1.8.12.1")]
 
 //
 // In order to sign your assembly you must specify a key to use. Refer to the 

--- a/sgmlreaderdll/SgmlReader.cs
+++ b/sgmlreaderdll/SgmlReader.cs
@@ -471,6 +471,12 @@ namespace Sgml
                 }
             }
 
+            // If DocType was specified explicitly, trust it.
+            if (this.m_dtd == null && this.m_ignoreDtd)
+            {
+                this.m_isHtml = StringUtilities.EqualsIgnoreCase(this.m_docType, "html");
+            }
+
             if (this.m_dtd != null && this.m_dtd.Name != null)
             {
                 switch(this.CaseFolding)
@@ -1417,9 +1423,9 @@ namespace Sgml
             if (this.m_current.ResolvedUri != null)
                 this.m_baseUri = this.m_current.ResolvedUri;
 
-            if (this.m_current.IsHtml && this.m_dtd == null)
+            if (this.m_current.IsHtml && this.m_dtd == null
+                && !StringUtilities.EqualsIgnoreCase(this.m_docType, "HTML"))   // No need to reload DTD in case m_docType == "HTML"
             {
-                this.m_docType = "HTML";
                 LazyLoadDtd(this.m_baseUri);
             }
         }


### PR DESCRIPTION
Consider folowing snippet:

```
            string toParse;
            toParse = "<p>one</p><p>two</p><p>three</p>";
            var sr = new StringReader(toParse);
            var NULL = "NULL";

            using (var reader = new SgmlReader()
                {InputStream = sr, DocType = "HTML", IgnoreDtd = true})
            {
                while (!reader.EOF)
                {
                    reader.Read();
                    WriteLine($"[{reader.NodeType,10}] {reader.Name ?? NULL,5}: " +
                        $"{reader.Value ?? NULL}");
                }
            }
```

On version 1.8.12 SGMLReader fails to read all document since it comes to this section twice:

```
            if (this.Depth == 1)
            {
                if (this.m_rootCount == 1)
                {
                    // Hmmm, we found another root level tag, soooo, the only
                    // thing we can do to keep this a valid XML document is stop
                    this.m_state = State.Eof;
                    return false;
                }
                this.m_rootCount++;
            }
```

It only returns the first `<p>` element and opening tag for second.

It was working in old good version 1.8.6, but I don't have a code of it, as on GitHub history starts from version 1.8.7 wich is already broken.

This commit allows to fix this behavior if user has set DocType to "HTML" explicitly.
